### PR TITLE
Re-use the same syntax for the tests as for writing the .env file.

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -45,14 +45,12 @@ jobs:
 
       - name: Debug container networking
         if: always()
-        env:
-          ELASTIC_ADMIN_PASSWORD: ${{ secrets.ELASTIC_ADMIN_PASSWORD }}
         run: |
           echo "==== CONTAINER STATUS ===="
           docker compose ps
           
           echo "==== ELASTICSEARCH STATUS ===="
-          docker compose exec -T elasticsearch curl -s -u elastic:"$ELASTIC_ADMIN_PASSWORD" http://localhost:9200/_cat/indices
+          docker compose exec -T elasticsearch curl -s -u elastic:${{ secrets.ELASTIC_ADMIN_PASSWORD}} http://localhost:9200/_cat/indices
           docker compose exec -T elasticsearch curl -s -u elastic:${{ secrets.ELASTIC_ADMIN_PASSWORD}} http://localhost:9200/_security/user
           
           echo "==== PROXY TEST ===="

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -45,13 +45,15 @@ jobs:
 
       - name: Debug container networking
         if: always()
+        env:
+          ELASTIC_ADMIN_PASSWORD: ${{ secrets.ELASTIC_ADMIN_PASSWORD }}
         run: |
           echo "==== CONTAINER STATUS ===="
           docker compose ps
           
           echo "==== ELASTICSEARCH STATUS ===="
-          docker compose exec -T elasticsearch curl -s -u elastic:${{ secrets.ELASTIC_ADMIN_PASSWORD || 'changeme' }} http://localhost:9200/_cat/indices
-          docker compose exec -T elasticsearch curl -s -u elastic:${{ secrets.ELASTIC_ADMIN_PASSWORD || 'changeme' }} http://localhost:9200/_security/user
+          docker compose exec -T elasticsearch curl -s -u elastic:"$ELASTIC_ADMIN_PASSWORD" http://localhost:9200/_cat/indices
+          docker compose exec -T elasticsearch curl -s -u elastic:${{ secrets.ELASTIC_ADMIN_PASSWORD}} http://localhost:9200/_security/user
           
           echo "==== PROXY TEST ===="
           docker compose exec -T proxy curl -s -u dictionary_reader:thisisgonnabepublic -H "Content-Type: application/json" http://elasticsearch:9200/dictionary/_search -d '{"query":{"match_all":{}}}'

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -50,8 +50,8 @@ jobs:
           docker compose ps
           
           echo "==== ELASTICSEARCH STATUS ===="
-          docker compose exec -T elasticsearch curl -s -u elastic:changeme http://localhost:9200/_cat/indices
-          docker compose exec -T elasticsearch curl -s -u elastic:changeme http://localhost:9200/_security/user
+          docker compose exec -T elasticsearch curl -s -u elastic:${{ secrets.ELASTIC_ADMIN_PASSWORD || 'changeme' }} http://localhost:9200/_cat/indices
+          docker compose exec -T elasticsearch curl -s -u elastic:${{ secrets.ELASTIC_ADMIN_PASSWORD || 'changeme' }} http://localhost:9200/_security/user
           
           echo "==== PROXY TEST ===="
           docker compose exec -T proxy curl -s -u dictionary_reader:thisisgonnabepublic -H "Content-Type: application/json" http://elasticsearch:9200/dictionary/_search -d '{"query":{"match_all":{}}}'


### PR DESCRIPTION
VS Code gives a warning, might be that the "||" fallback syntax does not work.