### PR TITLE
Improving Python dependencies

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+# Running the backend locally without Docker
+```
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt 
+fastapi dev main.py
+```
+After that, the endpoints are available under `http://127.0.0.1:8000`.
+# Known problems
+At the moment we added the Python backend, Python did not yet have a standard to manage dependencies similar to Node.js with a package.json and package-lock.json file. Thus currently the requirements.txt is created manually and not with the `pip freeze` command. Suggestions are welcome.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-fastapi[standard]
-uvicorn[standard]
-elasticsearch
-python-dotenv
+fastapi[standard]~=0.115.12
+uvicorn[standard]~=0.34.2
+elasticsearch==8.18.0
+python-dotenv~=1.1.0


### PR DESCRIPTION
Due to the lack of pinned versions in the Python dependencies, the Elastic client got updated and was now incomptabile with the not yet up-to-date Elastic Docker image.
Added a missing README to run the backend locally.