### PR TITLE
second attempt to fix github logo size

### DIFF
--- a/frontend/src/app/app.component.scss
+++ b/frontend/src/app/app.component.scss
@@ -60,6 +60,6 @@ mat-icon.github {
   }
 }
 
-mat-icon.toolbar-icon{
-  font-size: var(--mat-sys-label-large-size);
+mat-icon.toolbar-icon {
+  height: 24px;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b02185f6-aa26-4323-be5c-1bbdb099d487)
