### PR TITLE
Adjusting scaling after first problems in production. ;-)

### DIFF
--- a/containerapp-deploy.yaml
+++ b/containerapp-deploy.yaml
@@ -7,9 +7,9 @@ properties:
       - name: elastic-admin-password
 
     ingress:
-      external: true 
+      external: true
       targetPort: 80 # Mapping traffic to proxy container
-      transport: auto 
+      transport: auto
 
   template:
     containers:
@@ -34,13 +34,13 @@ properties:
           - name: ELASTIC_ADMIN_USERNAME
             value: elastic
           - name: ELASTIC_ADMIN_PASSWORD
-            secretRef: elastic-admin-password     
+            secretRef: elastic-admin-password
           - name: ELASTIC_INDEX
-            value: dictionary     
+            value: dictionary
           - name: ELASTIC_READER_USERNAME
             value: dictionary_reader
           - name: ELASTIC_READER_PASSWORD
-            value: thisisgonnabepublic     
+            value: thisisgonnabepublic
 
       - name: elasticsearch
         image: seislerwoerterbuech.azurecr.io/elasticsearch:latest
@@ -58,3 +58,12 @@ properties:
             value: false
           - name: discovery.type
             value: single-node
+
+    scale:
+      minReplicas: 1
+      maxReplicas: 10
+      rules:
+        - name: http-scaler
+          http:
+            metadata:
+              concurrentRequests: "50"


### PR DESCRIPTION
This morning there was already enough traffic to automatically create 2 replicas, for which the currently still manual Elasticsearch setup had to be run.

The default scaling rule seems to be a HTTP scaler which creates a replica whenever 10 concurrent requests are fired and it is checking every 30 seconds. I think with the peak of ~40 requests in 1 minute this triggered that rule.

According to the metrics CPU and RAM are no problem at all. 

![image](https://github.com/user-attachments/assets/1da43579-551a-40f5-95b9-a4eab427d7fd)
